### PR TITLE
fix: Provide an extra duration as fallback

### DIFF
--- a/videobench.py
+++ b/videobench.py
@@ -80,7 +80,11 @@ def manage_input_files(all_input, loglevel):
 			input_obj.path = input_path
 			input_obj.name, ext = os.path.splitext(filename)
 
-			input_obj.duration = float(ffprobe_json['streams'][0]['duration'])
+			try:
+				duration = ffprobe_json['streams'][0]['duration']
+			except KeyError:
+				duration = ffprobe_json['format']['duration']
+			input_obj.duration = float(duration)
 
 			fps_str = ffprobe_json['streams'][0]['r_frame_rate']
 			num,den = fps_str.split( '/' )

--- a/videobench_functions.py
+++ b/videobench_functions.py
@@ -264,7 +264,7 @@ def set_scaling_filter(ref_obj, input_obj):
 			input_obj.scale_filter = 'scale=3840:2160:flags={}'.format(input_obj.scale_filter)
 
 def get_video_streams_info(input_file, loglevel):  
-	cmd = "{0} ffprobe -loglevel {3} -print_format json -show_streams -select_streams v -i {1}{2}".format(docker_cmd , container_tmp_path, input_file, loglevel)
+	cmd = "{0} ffprobe -loglevel {3} -print_format json -show_format -show_streams -select_streams v -i {1}{2}".format(docker_cmd , container_tmp_path, input_file, loglevel)
 
 	if loglevel == "info":
 		print(cmd, flush=True)


### PR DESCRIPTION
For a video input I used, the `duration` field was missing from the video stream metadata, this PR provides a duration from the `format` metadata section which seems to be the same value. Without this a failure is encountered due to `KeyError` being thrown.